### PR TITLE
Fixed typo in schema name.

### DIFF
--- a/src/schemaType.js
+++ b/src/schemaType.js
@@ -2,7 +2,7 @@ import HtmlToPortableTextInput from "./index";
 
 export default {
     title: "HTML to Portable Text",
-    name: "htmlToProtableText",
+    name: "htmlToPortableText",
     type: "object",
     fields: [
         {


### PR DESCRIPTION
There's a typo in the schema name: `htmlToProtableText` should be `htmlToPortableText`.